### PR TITLE
Update homepage to emphasize AI-driven development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a static website for Martian Engineering, a software consulting firm. The site is built with vanilla HTML/CSS/JavaScript and is designed to be deployed as a static site (likely GitHub Pages, given the CNAME file).
+
+## Architecture
+
+- **index.html**: Main and only page containing company information, team profiles, and contact details
+- **assets/style.css**: All styling using Martian Mono font with responsive design
+- **script.js**: Minimal JavaScript for Urbit ID tooltip functionality
+- **assets/**: Static assets including favicon variants, logo, and Urbit logo
+- **CNAME**: Domain configuration for GitHub Pages deployment
+
+## Key Features
+
+- Responsive design with mobile navigation handling
+- Interactive tooltips on Urbit IDs (team member identifiers)
+- Static company profile page with team member bios
+- Contact integration via email links
+
+## Development Commands
+
+This is a static website with no build process. To develop locally:
+
+```bash
+# Serve locally (any simple HTTP server)
+python3 -m http.server 8000
+# or
+npx serve .
+```
+
+## Deployment
+
+The site appears to be configured for GitHub Pages deployment via the CNAME file pointing to the custom domain.

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
         <div class="content">
 
             <div class="hero">
-                <h1>Senior Engineers, State-of-the-Art Development Process</h1>
+                <h1>Hard Problems, Modern Solutions</h1>
                 <div class="cta">
                     <a class="no-underline red" href="mailto:clients@martian.engineering">Contact us</a>
                 </div>
@@ -39,27 +39,20 @@
             <div class="section">
                 <p class="lead">
                     We are a team of senior engineers who solve complex technical problems across diverse domains. 
-                    Our expertise spans systems programming, cryptography, distributed systems, and security—combined with 
-                    advanced AI-integrated development workflows that we've refined through years of practice and client work.
+                    Our expertise spans data engineering, network protocols, distributed systems, embedded systems, and security. 
+                    We combine deep technical knowledge with sophisticated AI development workflows to deliver robust, 
+                    production-ready solutions with exceptional thoroughness and quality.
                 </p>
             </div>
 
             <div class="section">
                 <h2>What We Do</h2>
-                <p>
-                    We tackle challenging engineering problems—from distributed systems and network protocols to smart contracts 
-                    and large-scale data pipelines. Our approach combines deep technical expertise with sophisticated AI development 
-                    workflows, enabling us to deliver robust, production-ready solutions with exceptional thoroughness and quality.
-                </p>
-                <p>
-                    Recent projects include:
-                </p>
+                <p>Recent projects include:</p>
                 <ul>
-                    <li>Custom MCP (Model Context Protocol) hosts with enterprise scaling</li>
+                    <li>Custom MCP (Model Context Protocol) host with enterprise scaling</li>
+                    <li>Large-scale data ingestion pipeline and embeddings generation</li>
+                    <li>Peer-to-peer network protocol design with economic incentives</li>
                     <li>Automated code review systems</li>
-                    <li>AI-powered applications across multiple tech stacks</li>
-                    <li>Developer training and AI adoption consulting</li>
-                    <li>Complex system integrations and data pipelines</li>
                 </ul>
                 <p>
                     We also help established engineering teams adopt AI development practices responsibly. We've trained teams 
@@ -133,18 +126,18 @@
                 </div>
 
                 <div class="person">
-                    <span class="name">Brian Bulag</span>
-                    <span class="comments">// computational biology, machine learning</span>
-                    <p class="bio">
-                        Brian's experience includes computational biology research and machine learning, particularly with kernel methods on social science data within The Institute for Quantitative Social Science at Harvard. He holds degrees in Biology and Philosophy from Stony Brook University, and is an avid Category Theory enthusiast.
-                    </p>
-                </div>
-
-                <div class="person">
                     <span class="urbit-id">~mopfel-winrux</span>
                     <span class="comments">// embedded systems, machine learning</span>
                     <p class="bio">
                         ~mopfel-winrux's previous experience includes processor development and positions at NASA and Lockheed Martin Research & Development. He holds a Ph.D. in Electrical Engineering from Georgia Tech.
+                    </p>
+                </div>
+
+                <div class="person">
+                    <span class="name">Brian Bulag</span>
+                    <span class="comments">// machine learning, data science</span>
+                    <p class="bio">
+                        Brian's experience includes computational biology research and machine learning, particularly with kernel methods on social science data within The Institute for Quantitative Social Science at Harvard. He holds degrees in Biology and Philosophy from Stony Brook University, and is an avid Category Theory enthusiast.
                     </p>
                 </div>
 
@@ -181,7 +174,7 @@
                 <!-- </a> -->
             </div>
             <div class="footer-right">
-                <span class="copyright">© 2024 Martian Engineering, LLC</span>
+                <span class="copyright">© 2025 Martian Engineering, LLC</span>
             </div>
         </footer>
 

--- a/index.html
+++ b/index.html
@@ -30,72 +30,66 @@
         <div class="content">
 
             <div class="hero">
-                <h1>We solve hard problems</h1>
+                <h1>Senior Engineers, State-of-the-Art Development Process</h1>
                 <div class="cta">
-                    <a class="no-underline red" href="mailto:team@martian.engineering">Contact us</a>
+                    <a class="no-underline red" href="mailto:clients@martian.engineering">Contact us</a>
                 </div>
             </div>
 
             <div class="section">
-                <p class="lead">We are a software consulting firm specializing
-                    in systems software engineering. Our team consists exclusively
-                    of senior software engineers and executives with over a decade
-                    of experience.</p>
-                <!-- <a class="red" href="/about">Learn more about us</a> -->
+                <p class="lead">
+                    We are a team of senior engineers who solve complex technical problems across diverse domains. 
+                    Our expertise spans systems programming, cryptography, distributed systems, and security—combined with 
+                    advanced AI-integrated development workflows that we've refined through years of practice and client work.
+                </p>
             </div>
 
             <div class="section">
-                <h2>Our Work</h2>
-                <div class="paragraph-with-image">
-                    <a href="https://urbit.org" target="_blank">
-                        <img src="assets/1200px-Urbit_Logo.png" alt="Urbit Logo" width="200px">
-                    </a>
-                    <p>
-                        Our team has a shared background through working
-                        together on <a href="https://urbit.org" target="_blank">Urbit</a>, a novel networked operating system.
-                        Together, we have shepherded several research projects
-                        from conception through production deployment across
-                        various domains.
-                    </p>
-                </div>
+                <h2>What We Do</h2>
                 <p>
-                    We are particularly well versed in tackling complex
-                    challenges in software engineering. Some examples:
+                    We tackle challenging engineering problems—from distributed systems and network protocols to smart contracts 
+                    and large-scale data pipelines. Our approach combines deep technical expertise with sophisticated AI development 
+                    workflows, enabling us to deliver robust, production-ready solutions with exceptional thoroughness and quality.
+                </p>
+                <p>
+                    Recent projects include:
                 </p>
                 <ul>
-                    <li>Network protocols</li>
-                    <li>Operating systems</li>
-                    <li>Memory management</li>
-                    <li>Embedded systems</li>
-                    <li>Applied cryptography</li>
-                    <li>Machine learning</li>
-                    <li>Performance optimization</li>
-                    <li>Security</li>
-                    <li>Distributed systems</li>
-                    <li>Data engineering and analysis</li>
+                    <li>Custom MCP (Model Context Protocol) hosts with enterprise scaling</li>
+                    <li>Automated code review systems</li>
+                    <li>AI-powered applications across multiple tech stacks</li>
+                    <li>Developer training and AI adoption consulting</li>
+                    <li>Complex system integrations and data pipelines</li>
+                </ul>
+                <p>
+                    We also help established engineering teams adopt AI development practices responsibly. We've trained teams 
+                    at major tech companies on integrating AI tools effectively while maintaining security practices and 
+                    compliance requirements—knowledge gained from years of building our own disciplined, production-ready workflows.
+                </p>
+            </div>
 
-                    <!-- <a class="red" href="/about">Learn more about us</a> -->
+            <div class="section">
+                <h2>We're Hiring</h2>
+                <p>
+                    We're looking for engineers who get things done, love to learn, and want to use the best tools available to build high-quality software across diverse industries and tech stacks.  If you're excited about joining a fast-paced environment and becoming top-notch at leveraging AI to build real software, we'd love to hear from you.
+                </p>
+                <p>
+                    <a class="red" href="mailto:jobs@martian.engineering">Send us your resume</a>
+                </p>
             </div>
 
             <div class="section">
                 <h2>Principals</h2>
-                <!-- Ted -->
                 <div class="person">
-                    <span class="name">Theodore Blackman</span>
-                    <span class="urbit-id">(~rovnys-ricfer)</span>
-                    <p class="bio">Theodore has deep expertise in managing technical projects, including a dozen-person team
-                        developing an operating system and network protocol, as Chief Technical Officer of the Urbit Foundation.
-                        Previous experience includes robotics, distributed systems, data engineering, full-stack web development,
-                        and
-                        embedded systems. He was a YC founder in 2011, and holds a degree in physics from MIT.</p>
+                    <span class="name">Ted Blackman</span>
+                    <p class="bio">
+                        Ted has deep expertise in managing technical projects, including a dozen-person team developing an operating system and network protocol, as Chief Technical Officer of the Urbit Foundation.  Previous experience includes robotics, distributed systems, data engineering, full-stack web development, and embedded systems. He was a YC founder in 2011, and holds a degree in physics from MIT.
+                    </p>
                 </div>
                 <div class="person">
                     <span class="name">Josh Lehman</span>
-                    <span class="urbit-id">(~wolref-podlex)</span>
-                    <p class="bio">Josh has been leading software organizations for over a decade. He has a knack for organizing
-                        teams of developers. Most recently he was the Executive Director of the Urbit Foundation, where he worked
-                        closely with Theodore on Urbit’s most ambitious core development projects. Previously Josh was the CTO and
-                        cofounder of Starcity (YC S16, acquired by Common in 2021).
+                    <p class="bio">
+                        Josh has been leading software organizations for over a decade. He has a knack for organizing teams of developers. Most recently he was the Executive Director of the Urbit Foundation, where he worked closely with Theodore on Urbit’s most ambitious core development projects. Previously Josh was the CTO and cofounder of Starcity (YC S16, acquired by Common in 2021).
                     </p>
                 </div>
             </div>
@@ -105,67 +99,52 @@
 
                 <div class="person">
                     <span class="name">Luke Champine</span>
-                    <span>(~watter-parter)</span>
-                    <span class="comments">// network protocols, cryptography
-                        <p class="bio">Luke is a 3rd-generation programmer specializing in cryptography, networking protocols,
-                            and performance optimization. Since dropping out of college to co-found Sia, a leading cloud storage cryptocurrency,
-                            he has worked across all layers of the stack, from ASIC mining firmware to JavaScript
-                            frontends; TCP multiplexing to distributed consensus; vectorized assembly to novel Merkle tree research, and
-                            more. He treats programming as an end in itself, and outside of work he enjoys tinkering with a new language
-                            designed for competitive programming.</p>
+                    <span class="comments">// network protocols, cryptography</span>
+                    <p class="bio">
+                        Luke is a 3rd-generation programmer specializing in cryptography, networking protocols, and performance optimization. Since dropping out of college to co-found Sia, a leading cloud storage cryptocurrency, he has worked across all layers of the stack, from ASIC mining firmware to JavaScript frontends; TCP multiplexing to distributed consensus; vectorized assembly to novel Merkle tree research, and more. He treats programming as an end in itself, and outside of work he enjoys tinkering with a new language designed for competitive programming.
+                    </p>
                 </div>
 
                 <div class="person">
                     <span class="name">Rikard Hjort</span>
-                    <span>(~bithex-topnym)</span>
                     <span class="comments">// decentralized finance, blockchain, security </span>
-                    <p class="bio">Rikard is a security auditor and DeFi
-                        developer who’s has spent the last five years securing a
-                        variety of protocols with billions of dollars worth of
-                        assets under management and led various auditing teams with
-                        a dozen employees. He previously worked on formal
-                        verification based audits and tools at Runtime Verification,
-                        Inc. and as a lead security researcher for Spearbit, one of
-                        the leading cryptocurrency and DeFi auditing organizations.
-                        He holds a M.S. in Computer Science from Chalmers University
-                        of Engineering, Sweden.
+                    <p class="bio">
+                        Rikard is a security auditor and DeFi developer who’s has spent the last five years securing a variety of protocols with billions of dollars worth of assets under management and led various auditing teams with a dozen employees. He previously worked on formal verification based audits and tools at Runtime Verification, Inc. and as a lead security researcher for Spearbit, one of the leading cryptocurrency and DeFi auditing organizations.  He holds a M.S. in Computer Science from Chalmers University of Engineering, Sweden.
+                    </p>
+                </div>
+
+                <div class="person">
+                    <span class="name">Phil Galebach</span>
+                    <span class="comments">// data engineering, full-stack development, AI optimization</span>
+                    <p class="bio">
+                        Phil is a data-focused technologist with a career spanning statistician, senior data engineer, business intelligence manager, digital health COO, and AI optimization specialist. Phil has a particular passion for entrepreneurial work, founding his first business while at Harvard.
+                    </p>
+                    <p>
+                        Since diving headfirst into LLMs, he has worked extensively across the AI stack: from agents and RAG systems to MCPs and workflow automation; database optimizations to full-stack development; healthcare IT systems to digital marketing platforms. His recent focus centers on redesigning our relationship with computers through AI-powered business optimizations. He's worked extensively with heavily regulated enterprises, startups and the USG.
                     </p>
                 </div>
 
                 <div class="person">
                     <span class="name">Liam Fitzgerald</span>
-                    <span>(~hastuc-dibtux)</span>
                     <span class="comments">// network protocols, application development </span>
-                    <p class="bio">Liam’s experience includes networking
-                    protocols, decentralized applications and developer tooling.
-                    His most recent project was an experimental application
-                    layer for Urbit that unified build systems, smart contracts
-                    and user facing applications, which involved subprojects
-                    spanning systems, frontend and application programming. His
-                    previous projects include Tlon’s secure decentralized
-                    messenger, which is the largest application on the Urbit
-                    platform, as well as working on the Urbit kernel in various
-                    capacities. He studied Biomedical Engineering and
-                    Mathematics at the University of Queensland before dropping
-                    out.
+                    <p class="bio">
+                        Liam’s experience includes networking protocols, decentralized applications and developer tooling.  His most recent project was an experimental application layer for Urbit that unified build systems, smart contracts and user facing applications, which involved subprojects spanning systems, frontend and application programming. His previous projects include Tlon’s secure decentralized messenger, which is the largest application on the Urbit platform, as well as working on the Urbit kernel in various capacities. He studied Biomedical Engineering and Mathematics at the University of Queensland before dropping out.
                     </p>
                 </div>
 
                 <div class="person">
-                    <span class="name">~mopfel-winrux</span>
+                    <span class="urbit-id">~mopfel-winrux</span>
                     <span class="comments">// embedded systems, machine learning</span>
-                    <p class="bio">~mopfel-winrux's previous experience includes processor development and positions at NASA and
-                        Lockheed Martin Research & Development. He holds a Ph.D. in Electrical Engineering from Georgia Tech.</p>
+                    <p class="bio">
+                        ~mopfel-winrux's previous experience includes processor development and positions at NASA and Lockheed Martin Research & Development. He holds a Ph.D. in Electrical Engineering from Georgia Tech.
+                    </p>
                 </div>
 
                 <div class="person">
-                    <span class="name">~barter-simsum</span>
+                    <span class="urbit-id">~barter-simsum</span>
                     <span class="comments">// operating systems, memory management</span>
-                    <p class="bio">~barter-simsum's previous experience includes implementing a novel fault-tolerant persistent
-                        memory allocator for Urbit, where he also used pointer compression to expand the addressable memory in a
-                        32-bit language interpreter. Before Urbit, ~barter-simsum worked at Microsoft on optimizing storage drivers
-                        in
-                        the Windows kernel. ~barter-simsum holds a B.S. in Computer Science from Miami University.
+                    <p class="bio">
+                        ~barter-simsum's previous experience includes implementing a novel fault-tolerant persistent memory allocator for Urbit, where he also used pointer compression to expand the addressable memory in a 32-bit language interpreter. Before Urbit, ~barter-simsum worked at Microsoft on optimizing storage drivers in the Windows kernel. ~barter-simsum holds a B.S. in Computer Science from Miami University.
                     </p>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -133,6 +133,14 @@
                 </div>
 
                 <div class="person">
+                    <span class="name">Brian Bulag</span>
+                    <span class="comments">// computational biology, machine learning</span>
+                    <p class="bio">
+                        Brian's experience includes computational biology research and machine learning, particularly with kernel methods on social science data within The Institute for Quantitative Social Science at Harvard. He holds degrees in Biology and Philosophy from Stony Brook University, and is an avid Category Theory enthusiast.
+                    </p>
+                </div>
+
+                <div class="person">
                     <span class="urbit-id">~mopfel-winrux</span>
                     <span class="comments">// embedded systems, machine learning</span>
                     <p class="bio">


### PR DESCRIPTION
- Shift focus from Urbit background to AI-augmented software development
- Update hero section with new tagline emphasizing senior engineers
- Revise company description to highlight technical expertise + AI workflows
- Add hiring section based on newsletter content
- Update services to showcase AI capabilities and responsible practices
- Maintain team bios to demonstrate depth of engineering experience
- Add CLAUDE.md for future development guidance

This positions Martian Engineering as experienced engineers who leverage sophisticated AI development workflows to solve complex technical problems.

🤖 Generated with [Claude Code](https://claude.ai/code)